### PR TITLE
Give each Tenet instance its own connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ let user = User::new(
 let created_user = tenant.add_user(&user).unwrap();
 ```
 
+Each `Tenet::new()` call builds its own independent database connection pool from
+the connection string it is given. Creating multiple `Tenet` instances - even
+with different connection strings, e.g. one per test - is safe: they do not
+share state and do not interfere with one another.
+
 ## Testing
 
 We use unit/integration tests. In order to run them you need `docker` running and have `cargo-nextest` installed. You can do this with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,8 @@ mod user;
 mod schema;
 mod postgresql;
 
-use std::sync::OnceLock;
 use log::info;
-use postgresql::{dbtenant::{DbTenant, DbTenantMessage}, dbuser::DbUser};
+use postgresql::{database::Pool, dbtenant::{DbTenant, DbTenantMessage}, dbuser::DbUser};
 use uuid::Uuid;
 
 pub use application::*;
@@ -67,13 +66,16 @@ pub use user::*;
 
 /// Default database URL used when no connection string is provided.
 pub static DEFAULT_DATABASE_URL: &str = "postgres://postgres:@localhost/stec_tenet";
-/// Stores the connection string for the database connection.
-static CONNECTION_STRING: OnceLock<String> = OnceLock::new();
 
 /// Main structure for interacting with the Tenet system.
 ///
 /// This structure is the primary entry point for working with the Tenet library.
 /// It manages the database connection and provides methods for managing tenants.
+///
+/// Each `Tenet` instance owns its own connection pool, built from the connection
+/// string it was constructed with. Creating multiple `Tenet` instances - even with
+/// different connection strings, e.g. one per test - is safe: each instance talks
+/// to its own database independently and instances do not interfere with each other.
 ///
 /// # Example
 ///
@@ -87,14 +89,21 @@ static CONNECTION_STRING: OnceLock<String> = OnceLock::new();
 /// let tenant = tenet.create_tenant("My Company".to_string()).unwrap();
 /// ```
 #[derive(Debug, Clone)]
-pub struct Tenet { }
+pub struct Tenet {
+    pool: Pool
+}
 
-
-unsafe impl Send for Tenet {}
-unsafe impl Sync for Tenet {}
 
 impl Tenet {
     /// Creates a new Tenet instance with the specified database connection.
+    ///
+    /// Each call builds and returns a fresh, independent connection pool for the
+    /// given connection string and runs any pending migrations against it. This
+    /// is in contrast to versions prior to the fix for
+    /// [issue #7](https://github.com/stec-ug-haftungsbeschrankt/tenet/issues/7), where the
+    /// connection string and pool were stored in process-wide statics: only the
+    /// first `Tenet::new()` call in a process took effect, and later calls with a
+    /// different connection string silently kept using the first pool.
     ///
     /// # Parameters
     ///
@@ -108,7 +117,7 @@ impl Tenet {
     ///
     /// let tenet = Tenet::new("postgres://user:password@localhost/mydb".to_string());
     /// ```
-    pub fn new(connection_string: String) -> Self {     
+    pub fn new(connection_string: String) -> Self {
         let database_url = if connection_string.is_empty() {
             info!("Database url not set, using default ConnectionString");
             DEFAULT_DATABASE_URL.to_string()
@@ -116,12 +125,9 @@ impl Tenet {
             connection_string
         };
 
-        if let Err(e) = CONNECTION_STRING.set(database_url) {
-            println!("ConnectionString {}", e);
-        }
+        let pool = postgresql::database::build_pool(&database_url);
 
-        //initialize_database();
-        Tenet { }
+        Tenet { pool }
     }
 
     /// Returns a list of all tenant IDs.
@@ -139,7 +145,7 @@ impl Tenet {
     /// let tenant_ids = tenet.get_tenant_ids();
     /// ```
     pub fn get_tenant_ids(&self) -> Vec<Uuid> {
-        if let Ok(tenants) = DbTenant::find_all() {
+        if let Ok(tenants) = DbTenant::find_all(&self.pool) {
             return tenants.iter().map(|t| t.id).collect();
         }
         Vec::new()
@@ -159,8 +165,8 @@ impl Tenet {
     ///
     /// Returns a `TenetError::NotFoundError` if the user or tenant is not found.
     pub fn get_tenant_id_by_username(&self, username: String) -> Result<uuid::Uuid, TenetError> {
-        let user = DbUser::find_by_email(username).unwrap();
-        if let Ok(tenant) = DbTenant::find(user.db_tenant_id.unwrap()) {
+        let user = DbUser::find_by_email(&self.pool, username).unwrap();
+        if let Ok(tenant) = DbTenant::find(&self.pool, user.db_tenant_id.unwrap()) {
             return Ok(tenant.id);
         }
 
@@ -181,9 +187,9 @@ impl Tenet {
     ///
     /// Returns a `TenetError::NotFoundError` if the user or tenant is not found.
     pub fn get_tenant_by_username(&self, username: String) -> Result<Tenant, TenetError> {
-        let user = DbUser::find_by_email(username).unwrap();
-        if let Ok(tenant) = DbTenant::find(user.db_tenant_id.unwrap()) {
-            return Ok(Tenant::from(&tenant));
+        let user = DbUser::find_by_email(&self.pool, username).unwrap();
+        if let Ok(tenant) = DbTenant::find(&self.pool, user.db_tenant_id.unwrap()) {
+            return Ok(Tenant::from_db(&tenant, self.pool.clone()));
         }
 
         Err(TenetError::NotFoundError)
@@ -199,8 +205,8 @@ impl Tenet {
     ///
     /// An `Option<Tenant>` containing the tenant if found, otherwise `None`.
     pub fn get_tenant_by_id(&self, tenant_id: uuid::Uuid) -> Option<Tenant> {
-        if let Ok(db_tenant) = DbTenant::find(tenant_id) {
-            return Some(Tenant::from(&db_tenant));
+        if let Ok(db_tenant) = DbTenant::find(&self.pool, tenant_id) {
+            return Some(Tenant::from_db(&db_tenant, self.pool.clone()));
         }
         None
     }
@@ -224,9 +230,9 @@ impl Tenet {
             title
         };
         
-        let updated_tenant = DbTenant::update(tenant_id, tenant_message)?;
+        let updated_tenant = DbTenant::update(&self.pool, tenant_id, tenant_message)?;
 
-        Ok(Tenant::from(&updated_tenant))
+        Ok(Tenant::from_db(&updated_tenant, self.pool.clone()))
     }
 
     /// Creates a new tenant.
@@ -255,9 +261,9 @@ impl Tenet {
         let tenant_message = DbTenantMessage {
             title
         };
-        let created_tenant = DbTenant::create(tenant_message)?;
+        let created_tenant = DbTenant::create(&self.pool, tenant_message)?;
 
-        Ok(Tenant::from(&created_tenant))
+        Ok(Tenant::from_db(&created_tenant, self.pool.clone()))
     }
 
     /// Deletes a tenant by its ID.
@@ -274,7 +280,7 @@ impl Tenet {
     ///
     /// Returns a `TenetError` if the deletion fails.
     pub fn delete_tenant(&self, tenant_id: uuid::Uuid) -> Result<(), TenetError> {
-        DbTenant::delete(tenant_id)?;
+        DbTenant::delete(&self.pool, tenant_id)?;
         Ok(())
     }
 }
@@ -301,6 +307,52 @@ mod tests {
         //node.rm();
     }
     
+    /// Regression test for https://github.com/stec-ug-haftungsbeschrankt/tenet/issues/7
+    ///
+    /// Previously, `Tenet::new()` stored its connection string and connection pool in
+    /// process-wide `OnceLock` statics, so only the *first* `Tenet::new()` call in a
+    /// process actually took effect. A second `Tenet::new()` call with a different
+    /// connection string would silently keep using the first instance's pool, and
+    /// stopping the first container (as this test does, mid-test) would break all
+    /// later usage in the process - even of `Tenet` instances built from a perfectly
+    /// valid, still-running connection string.
+    #[test]
+    fn multiple_tenet_instances_use_independent_pools_test() {
+        let node_a = Postgres::default().start().expect("Unable to start container A");
+        let host_a = node_a.get_host().unwrap();
+        let port_a = node_a.get_host_port_ipv4(5432).unwrap();
+        let connection_string_a = format!("postgres://postgres:postgres@{}:{}/postgres", host_a, port_a);
+
+        let node_b = Postgres::default().start().expect("Unable to start container B");
+        let host_b = node_b.get_host().unwrap();
+        let port_b = node_b.get_host_port_ipv4(5432).unwrap();
+        let connection_string_b = format!("postgres://postgres:postgres@{}:{}/postgres", host_b, port_b);
+
+        // Create the first Tenet instance and a tenant in its database.
+        let tenet_a = Tenet::new(connection_string_a);
+        let tenant_a = tenet_a.create_tenant("Tenant A".to_string()).unwrap();
+
+        // Creating a second Tenet instance against a *different* database must not
+        // silently reuse the first instance's connection string/pool.
+        let tenet_b = Tenet::new(connection_string_b);
+        let tenant_b = tenet_b.create_tenant("Tenant B".to_string()).unwrap();
+
+        // Each instance only sees the tenant created through itself.
+        assert!(tenet_a.get_tenant_by_id(tenant_a.id).is_some());
+        assert!(tenet_a.get_tenant_by_id(tenant_b.id).is_none());
+        assert!(tenet_b.get_tenant_by_id(tenant_b.id).is_some());
+        assert!(tenet_b.get_tenant_by_id(tenant_a.id).is_none());
+
+        // Stopping the first container must not affect the second, still-running,
+        // Tenet instance - this used to fail because both shared a single global pool.
+        node_a.stop().expect("Failed to stop postgres container A");
+
+        let reloaded_tenant_b = tenet_b.get_tenant_by_id(tenant_b.id).unwrap();
+        assert_eq!(tenant_b.title, reloaded_tenant_b.title);
+
+        node_b.stop().expect("Failed to stop postgres container B");
+    }
+
     #[test]
     fn create_tenant_test() {
         test_harness(|connection_string| {

--- a/src/postgresql/database.rs
+++ b/src/postgresql/database.rs
@@ -1,35 +1,38 @@
 use diesel::PgConnection;
 use diesel::r2d2::ConnectionManager;
 use log::info;
-use std::sync::OnceLock;
 
 use diesel_migrations::EmbeddedMigrations;
 use crate::diesel_migrations::MigrationHarness;
-use crate::CONNECTION_STRING;
 
-type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+/// Connection pool type backing a [`crate::Tenet`] instance.
+///
+/// Each `Tenet` owns its own `Pool`, built from the connection string it was
+/// constructed with. This is cheap to clone (it's an `Arc` internally), so
+/// multiple `Tenet` instances pointing at different databases can coexist in
+/// the same process without interfering with one another.
+pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
 pub type DbConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
-static POOL: OnceLock<Pool> = OnceLock::new();
+/// Builds a new connection pool for the given connection string and runs
+/// any pending migrations against it.
+pub fn build_pool(connection_string: &str) -> Pool {
+    info!("Initializing Tenet Database");
+    info!("Tenet connection string: {}", connection_string);
 
-pub fn connection() -> Result<DbConnection, r2d2::Error> {
-    let mutex = POOL.get_or_init(|| {       
-        info!("Initializing Tenet Database");
+    let manager = ConnectionManager::<PgConnection>::new(connection_string);
+    let pool = Pool::new(manager).expect("Failed to create db pool");
 
-        let connection_string = CONNECTION_STRING.get().expect("Unable to get connection string");
-        info!("Tenet connection string: {}", &connection_string);
+    info!("Running pending database migrations...");
+    let mut connection = pool.get().expect("Failed to get db connection");
+    connection.run_pending_migrations(MIGRATIONS).expect("Unable to run migrations");
+    info!("Database migrations completed");
 
-        let manager = ConnectionManager::<PgConnection>::new(connection_string);
-        let pool = Pool::new(manager).expect("Failed to create db pool");
+    pool
+}
 
-        info!("Running pending database migrations...");
-        let mut connection = pool.get().expect("Failed to get db connection");
-        connection.run_pending_migrations(MIGRATIONS).expect("Unable to run migrations");
-        info!("Database migrations completed");
-        
-        pool
-    });
-    mutex.get()
+pub fn connection(pool: &Pool) -> Result<DbConnection, r2d2::Error> {
+    pool.get()
 }

--- a/src/postgresql/dbapplication.rs
+++ b/src/postgresql/dbapplication.rs
@@ -9,6 +9,7 @@ use diesel::{
 use diesel::prelude::*;
 
 use super::database;
+use super::database::Pool;
 use super::dbtenant::DbTenant;
 use crate::TenetError;
 use crate::schema::applications;
@@ -53,20 +54,20 @@ impl From<DbApplicationMessage> for DbApplication {
 
 
 impl DbApplication {
-    pub fn find_all() -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_all(pool: &Pool) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let applications = applications::table.load::<DbApplication>(&mut connection)?;
         Ok(applications)
     }
 
-    pub fn find_by_tenant(id: Uuid) -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_tenant(pool: &Pool, id: Uuid) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let applications = applications::table.filter(applications::db_tenant_id.eq(id)).load(&mut connection)?;
         Ok(applications)
     }
 
-    pub fn find(tenant_id: uuid::Uuid, application_id: Uuid) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find(pool: &Pool, tenant_id: uuid::Uuid, application_id: Uuid) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let application = applications::table
             .filter(applications::id.eq(application_id))
             .filter(applications::db_tenant_id.eq(tenant_id))
@@ -74,8 +75,8 @@ impl DbApplication {
         Ok(application)
     }
 
-    pub fn create(application: DbApplicationMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn create(pool: &Pool, application: DbApplicationMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let new_application = DbApplication::from(application);
 
@@ -85,8 +86,8 @@ impl DbApplication {
         Ok(db_application)
     }
 
-    pub fn update(id: Uuid, application: DbApplicationMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn update(pool: &Pool, id: Uuid, application: DbApplicationMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let updated_application = diesel::update(applications::table)
             .filter(applications::id.eq(id))
@@ -95,8 +96,8 @@ impl DbApplication {
         Ok(updated_application)
     }
 
-    pub fn delete(id: Uuid) -> Result<usize, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn delete(pool: &Pool, id: Uuid) -> Result<usize, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let result = diesel::delete(
             applications::table.filter(applications::id.eq(id))

--- a/src/postgresql/dbrole.rs
+++ b/src/postgresql/dbrole.rs
@@ -9,6 +9,7 @@ use diesel::{
 use diesel::prelude::*;
 
 use super::database;
+use super::database::Pool;
 use super::dbtenant::DbTenant;
 use crate::TenetError;
 use crate::schema::roles;
@@ -57,20 +58,20 @@ impl From<DbRoleMessage> for DbRole {
 
 
 impl DbRole {
-    pub fn find_all() -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_all(pool: &Pool) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let roles = roles::table.load::<DbRole>(&mut connection)?;
         Ok(roles)
     }
 
-    pub fn find_by_tenant(id: Uuid) -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_tenant(pool: &Pool, id: Uuid) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let roles = roles::table.filter(roles::db_tenant_id.eq(id)).load(&mut connection)?;
         Ok(roles)
     }
 
-    pub fn find_by_user(tenant_id: Uuid, user_id: Uuid) -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_user(pool: &Pool, tenant_id: Uuid, user_id: Uuid) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let roles = roles::table
             .filter(roles::db_tenant_id.eq(tenant_id))
             .filter(roles::user_id.eq(user_id))
@@ -78,8 +79,8 @@ impl DbRole {
         Ok(roles)
     }
 
-    pub fn find(tenant_id: uuid::Uuid, id: Uuid) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find(pool: &Pool, tenant_id: uuid::Uuid, id: Uuid) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let role = roles::table
             .filter(roles::id.eq(id))
             .filter(roles::db_tenant_id.eq(tenant_id))
@@ -87,8 +88,8 @@ impl DbRole {
         Ok(role)
     }
 
-    pub fn create(role: DbRoleMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn create(pool: &Pool, role: DbRoleMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let new_role = DbRole::from(role);
 
@@ -98,8 +99,8 @@ impl DbRole {
         Ok(db_role)
     }
 
-    pub fn update(id: Uuid, role: DbRoleMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn update(pool: &Pool, id: Uuid, role: DbRoleMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let updated_role = diesel::update(roles::table)
             .filter(roles::id.eq(id))
@@ -108,8 +109,8 @@ impl DbRole {
         Ok(updated_role)
     }
 
-    pub fn delete(id: Uuid) -> Result<usize, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn delete(pool: &Pool, id: Uuid) -> Result<usize, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let result = diesel::delete(
             roles::table.filter(roles::id.eq(id))

--- a/src/postgresql/dbstorage.rs
+++ b/src/postgresql/dbstorage.rs
@@ -9,6 +9,7 @@ use diesel::{
 use diesel::prelude::*;
 
 use super::database;
+use super::database::Pool;
 use super::dbtenant::DbTenant;
 use crate::TenetError;
 use crate::schema::storages;
@@ -60,20 +61,20 @@ impl From<DbStorageMessage> for DbStorage {
 
 
 impl DbStorage {
-    pub fn find_all() -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_all(pool: &Pool) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let storages = storages::table.load::<DbStorage>(&mut connection)?;
         Ok(storages)
     }
 
-    pub fn find_by_tenant(id: Uuid) -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_tenant(pool: &Pool, id: Uuid) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let storages = storages::table.filter(storages::db_tenant_id.eq(id)).load(&mut connection)?;
         Ok(storages)
     }
 
-    pub fn find(tenant_id: uuid::Uuid, id: Uuid) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find(pool: &Pool, tenant_id: uuid::Uuid, id: Uuid) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let storage = storages::table
             .filter(storages::id.eq(id))
             .filter(storages::db_tenant_id.eq(tenant_id))
@@ -81,8 +82,8 @@ impl DbStorage {
         Ok(storage)
     }
 
-    pub fn create(storage: DbStorageMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn create(pool: &Pool, storage: DbStorageMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let new_storage = DbStorage::from(storage);
 
@@ -92,8 +93,8 @@ impl DbStorage {
         Ok(db_storage)
     }
 
-    pub fn update(id: Uuid, storage: DbStorageMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn update(pool: &Pool, id: Uuid, storage: DbStorageMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let updated_storage = diesel::update(storages::table)
             .filter(storages::id.eq(id))
@@ -102,8 +103,8 @@ impl DbStorage {
         Ok(updated_storage)
     }
 
-    pub fn delete(id: Uuid) -> Result<usize, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn delete(pool: &Pool, id: Uuid) -> Result<usize, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let result = diesel::delete(
             storages::table.filter(storages::id.eq(id))

--- a/src/postgresql/dbtenant.rs
+++ b/src/postgresql/dbtenant.rs
@@ -12,6 +12,7 @@ use diesel::prelude::*;
 use crate::TenetError;
 use crate::schema::tenants;
 use super::database;
+use super::database::Pool;
 
 
 #[derive(Serialize, Deserialize, AsChangeset)]
@@ -44,26 +45,26 @@ impl From<DbTenantMessage> for DbTenant {
 
 
 impl DbTenant {
-    pub fn find_all() -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_all(pool: &Pool) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let tenants = tenants::table.load::<DbTenant>(&mut connection)?;
         Ok(tenants)
     }
 
-    pub fn find(id: Uuid) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find(pool: &Pool, id: Uuid) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let tenant = tenants::table.filter(tenants::id.eq(id)).first(&mut connection)?;
         Ok(tenant)
     }
 
-    pub fn find_by_title(title: String) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_title(pool: &Pool, title: String) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let tenant = tenants::table.filter(tenants::title.eq(title)).first(&mut connection)?;
         Ok(tenant)
     }
 
-    pub fn create(tenant: DbTenantMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn create(pool: &Pool, tenant: DbTenantMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let new_tenant = DbTenant::from(tenant);
 
@@ -73,8 +74,8 @@ impl DbTenant {
         Ok(db_tenant)
     }
 
-    pub fn update(id: Uuid, tenant: DbTenantMessage) -> Result<Self, TenetError> {
-        let mut conn = database::connection()?;
+    pub fn update(pool: &Pool, id: Uuid, tenant: DbTenantMessage) -> Result<Self, TenetError> {
+        let mut conn = database::connection(pool)?;
 
         let db_tenant = diesel::update(tenants::table)
             .filter(tenants::id.eq(id))
@@ -83,8 +84,8 @@ impl DbTenant {
         Ok(db_tenant)
     }
 
-    pub fn delete(id: Uuid) -> Result<usize, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn delete(pool: &Pool, id: Uuid) -> Result<usize, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let res = diesel::delete(
                 tenants::table.filter(tenants::id.eq(id))

--- a/src/postgresql/dbuser.rs
+++ b/src/postgresql/dbuser.rs
@@ -11,6 +11,7 @@ use argon2::Config;
 use rand::Rng;
 
 use super::database;
+use super::database::Pool;
 use super::dbtenant::DbTenant;
 use crate::TenetError;
 use crate::schema::users;
@@ -79,14 +80,14 @@ impl From<DbUser> for DbUserMessage {
 
 
 impl DbUser {
-    pub fn find_by_tenant(tenant_id: Uuid) -> Result<Vec<Self>, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_tenant(pool: &Pool, tenant_id: Uuid) -> Result<Vec<Self>, TenetError> {
+        let mut connection = database::connection(pool)?;
         let users = users::table.filter(users::db_tenant_id.eq(tenant_id)).load(&mut connection)?;
         Ok(users)
     }
 
-    pub fn find(tenant_id: uuid::Uuid, user_id: Uuid) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find(pool: &Pool, tenant_id: uuid::Uuid, user_id: Uuid) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let user = users::table
             .filter(users::id.eq(user_id))
             .filter(users::db_tenant_id.eq(tenant_id))
@@ -94,16 +95,16 @@ impl DbUser {
         Ok(user)
     }
 
-    pub fn find_by_email(email: String) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_email(pool: &Pool, email: String) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let user = users::table
             .filter(users::email.eq(email))
             .first(&mut connection)?;
         Ok(user)
     }
 
-    pub fn find_by_tenant_and_email(tenant_id: uuid::Uuid, email: String) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn find_by_tenant_and_email(pool: &Pool, tenant_id: uuid::Uuid, email: String) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
         let user = users::table
             .filter(users::db_tenant_id.eq(tenant_id))
             .filter(users::email.eq(email))
@@ -111,8 +112,8 @@ impl DbUser {
         Ok(user)
     }
 
-    pub fn create(user: DbUserMessage) -> Result<Self, TenetError> {
-        let mut connection = database::connection()?;
+    pub fn create(pool: &Pool, user: DbUserMessage) -> Result<Self, TenetError> {
+        let mut connection = database::connection(pool)?;
 
         let mut new_user = DbUser::from(user);
         new_user.hash_password()?;
@@ -123,8 +124,8 @@ impl DbUser {
         Ok(db_user)
     }
 
-    pub fn update(id: Uuid, user: DbUserMessage) -> Result<Self, TenetError> {
-        let mut conn = database::connection()?;
+    pub fn update(pool: &Pool, id: Uuid, user: DbUserMessage) -> Result<Self, TenetError> {
+        let mut conn = database::connection(pool)?;
 
         let user = diesel::update(users::table)
             .filter(users::id.eq(id))
@@ -133,8 +134,8 @@ impl DbUser {
         Ok(user)
     }
 
-    pub fn delete(id: Uuid) -> Result<usize, TenetError> {
-        let mut conn = database::connection()?;
+    pub fn delete(pool: &Pool, id: Uuid) -> Result<usize, TenetError> {
+        let mut conn = database::connection(pool)?;
 
         let res = diesel::delete(
             users::table.filter(users::id.eq(id))

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -1,57 +1,71 @@
 use chrono::{Utc, NaiveDateTime};
 
 use crate::{
-    error::TenetError, 
-    user::User, 
-    postgresql::{dbtenant::DbTenant, dbuser::{DbUser, DbUserMessage}, 
-    dbapplication::{DbApplication, DbApplicationMessage}, 
-    dbrole::{DbRole, DbRoleMessage}, 
-    dbstorage::{DbStorage, DbStorageMessage}}, 
-    Application, 
-    Role, 
+    error::TenetError,
+    postgresql::database::Pool,
+    user::User,
+    postgresql::{dbtenant::DbTenant, dbuser::{DbUser, DbUserMessage},
+    dbapplication::{DbApplication, DbApplicationMessage},
+    dbrole::{DbRole, DbRoleMessage},
+    dbstorage::{DbStorage, DbStorageMessage}},
+    Application,
+    Role,
     Storage
 };
 
 
-#[derive(Debug, Clone, serde_derive::Serialize, serde_derive::Deserialize, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Tenant {
     pub id: uuid::Uuid,
     pub title: String,
     pub created_at: NaiveDateTime,
-    pub updated_at: Option<NaiveDateTime>
+    pub updated_at: Option<NaiveDateTime>,
+    #[serde(skip, default = "disconnected_pool")]
+    pub(crate) pool: Pool
 }
 
-impl From<&DbTenant> for Tenant {
-    fn from(value: &DbTenant) -> Self {
-        Tenant { 
-            id: value.id, 
+fn disconnected_pool() -> Pool {
+    Pool::builder().build_unchecked(diesel::r2d2::ConnectionManager::new(""))
+}
+
+impl Tenant {
+    pub(crate) fn from_db(value: &DbTenant, pool: Pool) -> Self {
+        Tenant {
+            id: value.id,
             title: value.title.clone(),
-            created_at: value.created_at, 
-            updated_at: value.updated_at 
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            pool
         }
     }
 }
 
 impl Tenant {
+    /// Creates a transient, unsaved `Tenant` value not yet associated with any database.
+    ///
+    /// This value is not connected to a database, so calling any of `Tenant`'s
+    /// methods that read or write data will fail. Obtain a usable `Tenant` from
+    /// `Tenet::create_tenant`, `Tenet::get_tenant_by_id`, or similar lookup methods.
     pub fn new(title: String) -> Self {
-        Tenant { 
-            id: uuid::Uuid::new_v4(), 
+        Tenant {
+            id: uuid::Uuid::new_v4(),
             title,
             created_at: Utc::now().naive_utc(),
-            updated_at: None
+            updated_at: None,
+            pool: disconnected_pool()
         }
     }
 
     /* Users */
     pub fn get_users(&self) -> Vec<User> {
-        if let Ok(db_users) = DbUser::find_by_tenant(self.id) {
+        if let Ok(db_users) = DbUser::find_by_tenant(&self.pool, self.id) {
             return db_users.iter().map(User::from).collect();
         }
         Vec::new()
     }
 
     pub fn get_user_ids(&self) -> Vec<uuid::Uuid> {
-        if let Ok(users) = DbUser::find_by_tenant(self.id) {
+        if let Ok(users) = DbUser::find_by_tenant(&self.pool, self.id) {
             return users.iter().map(|u| u.id).collect();
         }
         Vec::new()
@@ -66,39 +80,39 @@ impl Tenant {
             full_name: user.full_name.clone(),
             db_tenant_id: user.db_tenant_id
         };
-        let created_user = DbUser::create(user_message)?;
+        let created_user = DbUser::create(&self.pool, user_message)?;
 
         Ok(User::from(&created_user))
     }
 
     pub fn get_user_by_id(&self, user_id: uuid::Uuid) -> Result<User, TenetError> {
-        let user = DbUser::find(self.id, user_id)?;
+        let user = DbUser::find(&self.pool, self.id, user_id)?;
         Ok(User::from(&user))
     }
 
     pub fn delete_user(&self, user_id: uuid::Uuid) -> Result<(), TenetError> {
-        DbUser::delete(user_id)?;
+        DbUser::delete(&self.pool, user_id)?;
         Ok(())
     }
 
     pub fn contains_username(&self, username: String) -> bool {
-        DbUser::find_by_tenant_and_email(self.id, username).is_ok()
+        DbUser::find_by_tenant_and_email(&self.pool, self.id, username).is_ok()
     }
 
     pub fn set_user_verified(&self, user_id: uuid::Uuid) -> bool {
-        if let Ok(user) = DbUser::find(self.id, user_id) {
+        if let Ok(user) = DbUser::find(&self.pool, self.id, user_id) {
             let user_message = DbUserMessage::from(user);
-            return DbUser::update(user_id, user_message).is_ok();
+            return DbUser::update(&self.pool, user_id, user_message).is_ok();
         }
         false
     }
 
     pub fn authenticate_user(&self, username: String, password: String) -> Option<User> {
-        if let Ok(user) = DbUser::find_by_tenant_and_email(self.id, username) {
+        if let Ok(user) = DbUser::find_by_tenant_and_email(&self.pool, self.id, username) {
             if let Ok(verified) = user.verify_password(&password) {
                 if verified {
                     return Some(User::from(&user))
-                }        
+                }
             }
         }
         None
@@ -106,14 +120,14 @@ impl Tenant {
 
     /* Applications */
     pub fn get_applications(&self) -> Vec<Application> {
-        if let Ok(applications) = DbApplication::find_by_tenant(self.id) {
+        if let Ok(applications) = DbApplication::find_by_tenant(&self.pool, self.id) {
             return applications.iter().map(Application::from).collect();
         }
-        Vec::new()      
+        Vec::new()
     }
 
     pub fn get_application_by_id(&self, application_id: uuid::Uuid) -> Result<Application, TenetError> {
-        let application = DbApplication::find(self.id, application_id)?;
+        let application = DbApplication::find(&self.pool, self.id, application_id)?;
         Ok(Application::from(&application))
     }
 
@@ -123,26 +137,26 @@ impl Tenant {
             storage_id: application.storage_id,
             db_tenant_id: application.db_tenant_id
         };
-        let created_application = DbApplication::create(application_message)?;
+        let created_application = DbApplication::create(&self.pool, application_message)?;
 
         Ok(Application::from(&created_application))
     }
 
     pub fn delete_application(&self, application_id: uuid::Uuid) -> Result<(), TenetError> {
-        DbApplication::delete(application_id)?;
+        DbApplication::delete(&self.pool, application_id)?;
         Ok(())
     }
 
     /* Storage */
     pub fn get_storages(&self) -> Vec<Storage> {
-        if let Ok(storages) = DbStorage::find_by_tenant(self.id) {
+        if let Ok(storages) = DbStorage::find_by_tenant(&self.pool, self.id) {
             return storages.iter().map(Storage::from).collect();
         }
-        Vec::new()      
+        Vec::new()
     }
 
     pub fn get_storage_by_id(&self, storage_id: uuid::Uuid) -> Result<Storage, TenetError> {
-        let storage = DbStorage::find(self.id, storage_id)?;
+        let storage = DbStorage::find(&self.pool, self.id, storage_id)?;
         Ok(Storage::from(&storage))
     }
 
@@ -155,26 +169,26 @@ impl Tenant {
             table_prefix: storage.table_prefix.clone(),
             db_tenant_id: storage.db_tenant_id
         };
-        let created_storage = DbStorage::create(storage_message)?;
+        let created_storage = DbStorage::create(&self.pool, storage_message)?;
 
         Ok(Storage::from(&created_storage))
     }
 
     pub fn delete_storage(&self, storage_id: uuid::Uuid) -> Result<(), TenetError> {
-        DbStorage::delete(storage_id)?;
+        DbStorage::delete(&self.pool, storage_id)?;
         Ok(())
     }
 
     /* Roles */
     pub fn get_roles(&self) -> Vec<Role> {
-        if let Ok(roles) = DbRole::find_by_tenant(self.id) {
+        if let Ok(roles) = DbRole::find_by_tenant(&self.pool, self.id) {
             return roles.iter().map(Role::from).collect();
         }
         Vec::new()
     }
 
     pub fn get_role_by_id(&self, role_id: uuid::Uuid) -> Result<Role, TenetError> {
-        let role = DbRole::find(self.id, role_id)?;
+        let role = DbRole::find(&self.pool, self.id, role_id)?;
         Ok(Role::from(&role))
     }
 
@@ -185,19 +199,18 @@ impl Tenant {
             application_id: role.application_id,
             db_tenant_id: role.db_tenant_id
         };
-        let created_role = DbRole::create(role_message)?;
+        let created_role = DbRole::create(&self.pool, role_message)?;
 
         Ok(Role::from(&created_role))
     }
 
     pub fn delete_role(&self, role_id: uuid::Uuid) -> Result<(), TenetError> {
-        DbRole::delete(role_id)?;
+        DbRole::delete(&self.pool, role_id)?;
         Ok(())
     }
 
     pub fn get_roles_for_user(&self, user_id: uuid::Uuid) -> Result<Vec<Role>, TenetError> {
-        // Nutze die spezifische Methode, um die Rollen direkt zu finden
-        let user_roles = DbRole::find_by_user(self.id, user_id)?;
+        let user_roles = DbRole::find_by_user(&self.pool, self.id, user_id)?;
 
         Ok(user_roles.iter().map(Role::from).collect())
     }


### PR DESCRIPTION
## Summary
- `Tenet::new()` used to store the connection string and the lazily-built postgres pool in process-wide `OnceLock` statics, so only the first `Tenet::new()` call in a process actually took effect — later calls with a different connection string silently kept the first pool, and stopping the first database broke every subsequent `Tenet` usage in the process.
- Each `Tenet` (and the `Tenant` values it returns) now owns its own `r2d2` connection pool built from the connection string it was constructed with. The pool is threaded through all of the `postgresql::db*` query functions instead of being read from a global.
- Documented the new per-instance pool behavior in the `Tenet::new()` doc comment and the README.

Fixes #7

## Test plan
- [x] `cargo test --lib` — all 20 tests pass, including a new regression test `multiple_tenet_instances_use_independent_pools_test` that spins up two separate Postgres testcontainers, creates two `Tenet` instances against them, verifies each only sees its own tenant data, then stops the first container and confirms the second `Tenet` instance keeps working.