### PR TITLE
Fix crates.io publish and modernize CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build artifact and publish to crates.io
 
 on:
   push:
@@ -15,14 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Install nextest
-      run: cargo install cargo-nextest --locked
-    - name: Run tests
-      run: cargo nextest run --verbose
-    #- name: Login on crates.io
-    #  run: cargo login
-    - name: Publish to crates.io
-      run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} --allow-dirty
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install nextest
+        run: cargo binstall --no-confirm cargo-nextest
+      - name: Build and run tests
+        run: cargo nextest run --verbose
+      - name: Publish to crates.io
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --allow-dirty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 readme = "README.md"
 homepage = "https://stecug.de"
 repository = "https://github.com/stec-ug-haftungsbeschrankt/tenet/"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary
- `cargo publish` was failing in CI because version `0.3.2` was already published to crates.io, and the workflow ran the publish step unconditionally on every push *and* every pull request — bumped the crate version to `0.3.3`.
- Reworked `.github/workflows/rust.yml`, taking inspiration from the `stec_shopster` pipeline:
  - Publish only runs `on: push` to `master` (not on PRs, where the version hasn't changed yet).
  - Uses `cargo-binstall` + `Swatinem/rust-cache` to install `cargo-nextest` faster instead of `cargo install --locked`.
  - Passes the crates.io token via the non-deprecated `CARGO_REGISTRY_TOKEN` env var instead of `cargo publish --token ...`.

## Test plan
- [x] `cargo nextest run` succeeds locally
- [ ] CI run on this PR (publish step should be skipped since this is a PR, not a push to master)
- [ ] Merge to master and confirm `cargo publish` succeeds for 0.3.3