### PR TITLE
Fix flaky CI: force reinstall of cargo-nextest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: cargo-bins/cargo-binstall@main
       - name: Install nextest
-        run: cargo binstall --no-confirm cargo-nextest
+        run: cargo binstall --no-confirm --force cargo-nextest
       - name: Build and run tests
         run: cargo nextest run --verbose
       - name: Publish to crates.io


### PR DESCRIPTION
## Summary
- CI run [28428280336](https://github.com/stec-ug-haftungsbeschrankt/tenet/actions/runs/28428280336) failed with `error: no such command: nextest`.
- `Swatinem/rust-cache@v2` restores cargo's install-receipt file (`.crates2.json`) from cache, which can report `cargo-nextest` as already installed even when the actual binary wasn't restored to `~/.cargo/bin`.
- `cargo binstall` saw the stale receipt and skipped installation, so the later `cargo nextest run` step failed because the binary was missing.
- Fix: pass `--force` to `cargo binstall` so it always (re)installs cargo-nextest regardless of cached receipts.

## Test plan
- [ ] Confirm the next CI run on this PR successfully installs cargo-nextest and runs tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)